### PR TITLE
bdist_wheel not found fix

### DIFF
--- a/snips.ai/Dockerfile
+++ b/snips.ai/Dockerfile
@@ -11,13 +11,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install dirmngr \
     mpg123 \
     git \
     gnupg \
-    python \
-    python-pip \
-    python-wheel \
     python3 \
-    python3-pip \
-    python3-venv \
-    python3-wheel &&\
+    python3-venv &&\
     apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$(uname --m)" = 'aarch64' ]; then bash -c 'echo "deb https://raspbian.snips.ai/410c_linaro_buster stable main" > /etc/apt/sources.list.d/snips.list'; fi &&\
@@ -35,8 +30,6 @@ RUN if [ "$(uname --m)" = 'aarch64' ]; then bash -c 'echo "deb https://raspbian.
         snips-template \
         snips-watch &&\
     apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install --upgrade setuptools wheel virtualenv && pip2 install --upgrade setuptools wheel virtualenv
 
 COPY run.sh /
 RUN chmod a+x /run.sh

--- a/snips.ai/run.sh
+++ b/snips.ai/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bashio
 set -e
+set +u
 
 bashio::log.info "Setup Settings"
 
@@ -30,14 +31,18 @@ snips-template render
 
 pushd /var/lib/snips/skills
 
-
 for url in $(awk '$1=="url:" {print $2}' /usr/share/snips/assistant/Snipsfile.yaml); do
   git clone "$url"
 done
 
+mkdir /share
+
 find . -maxdepth 1 -type d -print0 | while IFS= read -r -d '' dir; do
     pushd "$dir" > /dev/null
     if [ -f setup.sh ]; then
+        python3 -m venv venv
+        source venv/bin/activate
+        pip3 install --upgrade pip setuptools wheel
         bashio::log.info "Run setup.sh for '$dir'"
         bash ./setup.sh
     fi


### PR DESCRIPTION
Fix wheel beeing not installed in the individual venvs of snips packages.

Installing wheel via apt-get did not help as every snips setup.sh creates a new venv as long as there is not already a venv available.