### PR TITLE
Update Build system

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -51,9 +51,6 @@ jobs:
           "rsync"
         ]
       fail-fast: false
-    container:
-      image: homeassistant/amd64-builder:7.2.0
-      options: --rm --privileged
     steps:
       - name: Detect chanced files
         id: files-check
@@ -89,12 +86,14 @@ jobs:
 
       - name: Build addon
         if: steps.files-check.outputs.changed == 'true'
-        run: >
-          /usr/bin/builder.sh ${{ steps.config.outputs.archs_param }} 
-          -t ${{ matrix.addon }} 
-          -d ${{ steps.config.outputs.registry }} 
-          -i ${{ steps.config.outputs.imagetemplate }}
-          --test
+        uses: home-assistant/builder@2020.10.0
+        with:
+          args: >
+            ${{ steps.config.outputs.archs_param }} 
+            -t /data/${{ matrix.addon }} 
+            -d ${{ steps.config.outputs.registry }} 
+            -i ${{ steps.config.outputs.imagetemplate }}
+            --test
 
       - name: Check images
         if: steps.files-check.outputs.changed == 'true'

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -93,6 +93,8 @@ jobs:
             -t /data/${{ matrix.addon }} 
             -d ${{ steps.config.outputs.registry }} 
             -i ${{ steps.config.outputs.imagetemplate }}
+            --cache-tag cache
+            --no-latest
             --test
 
       - name: Check images

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -89,9 +89,9 @@ jobs:
         uses: home-assistant/builder@2020.10.0
         with:
           args: >
-            ${{ steps.config.outputs.archs_param }} 
-            -t /data/${{ matrix.addon }} 
-            -d ${{ steps.config.outputs.registry }} 
+            ${{ steps.config.outputs.archs_param }}
+            -t /data/${{ matrix.addon }}
+            -d ${{ steps.config.outputs.registry }}
             -i ${{ steps.config.outputs.imagetemplate }}
             --cache-tag cache
             --no-latest

--- a/.github/workflows/master-push.yaml
+++ b/.github/workflows/master-push.yaml
@@ -80,6 +80,8 @@ jobs:
             -t /data/${{ matrix.addon }}
             -d ${{ steps.config.outputs.registry }}
             -i ${{ steps.config.outputs.imagetemplate }}
+            --cache-tag cache
+            --no-latest
             --test
 
       - name: Check images
@@ -100,14 +102,18 @@ jobs:
             exit 1
           fi
 
-      - name: Add repository labels
+      - name: Add docker image labels and tags
         if: steps.files-check.outputs.changed == 'true'
         shell: bash
         run: |
           for image_name in ${{ steps.config.outputs.image_names }}; do
-            echo "FROM $image_name:latest" | docker build --label org.opencontainers.image.source="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" -t "$image_name:latest" -
-            echo "FROM $image_name:${{ steps.config.outputs.version }}" | docker build --label org.opencontainers.image.source="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+            echo "FROM $image_name:${{ steps.config.outputs.version }}" | docker build \
+              --label org.opencontainers.image.source="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
               -t "$image_name:${{ steps.config.outputs.version }}" -
+
+            echo "FROM $image_name:${{ steps.config.outputs.version }}" | docker build \
+              --label org.opencontainers.image.revision.name=cache \
+              -t "$image_name:cache" -
           done
 
       - name: Docker Login
@@ -124,6 +130,5 @@ jobs:
         run: |
           for image_name in ${{ steps.config.outputs.image_names }}; do
             docker push "$image_name:${{ steps.config.outputs.version }}"
-            docker push "$image_name:latest"
-            echo "Pushed $image_name"
+            docker push "$image_name:cache"
           done

--- a/.github/workflows/master-push.yaml
+++ b/.github/workflows/master-push.yaml
@@ -25,9 +25,6 @@ jobs:
           "rsync"
         ]
       fail-fast: false
-    container:
-      image: homeassistant/amd64-builder:7.2.0
-      options: --rm --privileged
     steps:
       - name: Git install
         run: |
@@ -74,14 +71,16 @@ jobs:
           echo "::set-output name=archs_param::$archs_param"
           echo "::set-output name=image_names::$image_names"
 
-      - name: Build addon images
+      - name: Build addon
         if: steps.files-check.outputs.changed == 'true'
-        run: >
-          /usr/bin/builder.sh ${{ steps.config.outputs.archs_param }} 
-          -t ${{ matrix.addon }} 
-          -d ${{ steps.config.outputs.registry }} 
-          -i ${{ steps.config.outputs.imagetemplate }}
-          --test
+        uses: home-assistant/builder@2020.10.0
+        with:
+          args: >
+            ${{ steps.config.outputs.archs_param }}
+            -t /data/${{ matrix.addon }}
+            -d ${{ steps.config.outputs.registry }}
+            -i ${{ steps.config.outputs.imagetemplate }}
+            --test
 
       - name: Check images
         if: steps.files-check.outputs.changed == 'true'


### PR DESCRIPTION
* Use provided GitHub Action instead of docker image (Nearly the same)
* Use dedicated cache image, to keep the download numbers real.