### PR TITLE
Updated ICantBelieveItsNotValetudo to make it fully work with 2021.02.1

### DIFF
--- a/ICantBelieveItsNotValetudo/CHANGELOG.md
+++ b/ICantBelieveItsNotValetudo/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.0 - 2021-02-27
+
+* 🔼 Updated ICantBelieveItsNotValetudo to latest commit `73a7965` to make it fully compatible with Valetudo > 2021.02.1
+* 🔼 Updated npm to `14.16.0-r0`
+* ➖ Removed `homeassistantMapHack` notice
+
+
 ## 2.8.1 - 2021-02-20
 
 * 🔼 Updated python3 to `3.8.7-r1`

--- a/ICantBelieveItsNotValetudo/Dockerfile
+++ b/ICantBelieveItsNotValetudo/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG C.UTF-8
 
 RUN apk add --no-cache \
 	git=2.30.1-r0 \
-	npm=14.15.5-r0 \
+	npm=14.16.0-r0 \
 	python3=3.8.7-r1 \
 	pixman-dev=0.40.0-r2 \
 	cairo-dev=1.16.0-r2 \
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 	build-base=0.5-r2 \
 	libjpeg-turbo-dev=2.0.6-r0
 
-ENV COMMIT_SHA '74b6c334e44c063c5f9ab9f64cc136daaeafad7c'
+ENV COMMIT_SHA '73a7965704027ec37a302545821d688e73df0c3e'
 # hadolint ignore=DL3003
 RUN git config --global advice.detachedHead false && \
     git clone https://github.com/Hypfer/ICantBelieveItsNotValetudo.git -b master /app && \
@@ -24,7 +24,8 @@ RUN npm install
 
 FROM $BUILD_FROM AS RUNNING
 
-RUN apk add --no-cache npm=14.15.5-r0 \
+RUN apk add --no-cache \
+    npm=14.16.0-r0 \
     pixman=0.40.0-r2 \
 	cairo=1.16.0-r2 \
 	pango=1.48.2-r0 \

--- a/ICantBelieveItsNotValetudo/README.md
+++ b/ICantBelieveItsNotValetudo/README.md
@@ -12,8 +12,6 @@ It's normal that the structure of the addon differs from the official config fil
 
 If you use the Mosquitto Addon in Home Assistant `core-mosquitto` can be used as broker address like this: `mqtt://<user>:<password>@core-mosquitto`.
 
-⚠️ To make the addon work correctly the `homeassistantMapHack` on Valetudo 2021.02.0 must be set to false. This will disable the valetudo-card! A fix for it is coming soon.
-
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-%23d32f2f?logo=buy-me-a-coffee&style=for-the-badge&logoColor=white)](https://www.buymeacoffee.com/Poeschl)
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg

--- a/ICantBelieveItsNotValetudo/config.json
+++ b/ICantBelieveItsNotValetudo/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ICantBelieveItsNotValetudo",
-  "version": "2.8.1",
+  "version": "3.0.0",
   "slug": "icantbelieveitsnotvaletudo",
   "description": "This is a simple companion service for valetudo which generates the map pngs.",
   "url": "https://github.com/Poeschl/Hassio-Addons/tree/master/ICantBelieveItsNotValetudo",


### PR DESCRIPTION
The update to make the addon also compatible with the latest Valetudo mapdata without the `homeassistanthack` mode.

@Kugelfang666 and @tlpbu could you test this PR code for me? I'm not close to a robot nor MQTT broker right now.

Steps to install the PR changes:
* Unzip the [beta archive](https://github.com/Poeschl/Hassio-Addons/files/6055067/ICantBelieveItsNotValetudo-3.0.0-beta.zip) to your `/addons` share
* Goto the supervisor Addon Shop and Refresh on the top right menu
* Install the Local Addon `ICantBelieveItsNotValetudo` (This will not replace the existing one, and might take like 20 Minutes)
