### PR TITLE
[git-exporter] clean repo before proceeding

### DIFF
--- a/git-exporter/CHANGELOG.md
+++ b/git-exporter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.14.0 - 2022-11-05
 
 * ✨ Allow customising secret patterns (thanks @bjeanes #316)
+* 🔨 Clean untracked files from working directory before syncing latest config (thanks @bjeanes #317)
 * 🔼 Updated git to `2.36.3-r0`
 * 🔼 Updated rsync to `3.2.7-r0`
 
@@ -177,4 +178,3 @@
 * ➕ ESPHome exports
 * ➕ Configurable Commit message
 * ➕ Configurable exports
-

--- a/git-exporter/root/run.sh
+++ b/git-exporter/root/run.sh
@@ -49,6 +49,8 @@ function setup_git {
         git fetch
         git reset --hard "origin/$branch"
     fi
+
+    git clean -f -d
 }
 
 function check_secrets {


### PR DESCRIPTION
After successive dry-runs, if `exclude` option is amended, now-excluded
files will accumulate in the git directory with no real way to discard
them.

Running `git clean` after clone will ensure a clean slate before
re-`rsync`ing files over and `git add`ing them.