### PR TITLE
rsync-local/config.yaml: Make external_devices more permissive

### DIFF
--- a/rsync-local/CHANGELOG.md
+++ b/rsync-local/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.x.x - 2023-xx-xx
+
+* 🔨 Make external_devices more permissive (#427)
+
 ## 1.6.0 - 2023-01-08
 
 * 🔼 Updated rsync to `3.2.7-r0`

--- a/rsync-local/config.yaml
+++ b/rsync-local/config.yaml
@@ -35,7 +35,7 @@ schema:
     - source: str
       options: str?
   external_folder: match(^[^/].+)
-  external_device: match(^(/dev/sd[a|b][1|2])?)
+  external_device: match(^(/dev/[hsv]d[a-z][1-9])?)
 options:
   folders:
     - source: /config


### PR DESCRIPTION
`/dev/hd`, `/dev/sd` and `/dev/vd` are all valid prefixes, with letters a-z, and potentially more than 9 partitions too...

Ping https://github.com/Poeschl/Hassio-Addons/issues/381