### PR TITLE
Update to latest valetudo-mapper

### DIFF
--- a/valetudo-mapper/CHANGELOG.md
+++ b/valetudo-mapper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.0 - 2023-10-14
+
+* 🔼 Update Valetudo-Mapper to latest version
+
 ## 1.11.0 - 2022-08-03
 
 * 🔼 Update Valetudo-Mapper to commit `bd97779`

--- a/valetudo-mapper/CHANGELOG.md
+++ b/valetudo-mapper/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.12.0 - 2023-10-14
 
-* 🔼 Update Valetudo-Mapper to latest version
+* 🔼 Update Valetudo-Mapper to commit `54aba35`
 
 ## 1.11.0 - 2022-08-03
 

--- a/valetudo-mapper/Dockerfile
+++ b/valetudo-mapper/Dockerfile
@@ -5,11 +5,11 @@ ENV LANG C.UTF-8
 
 RUN apk add --no-cache git=2.36.2-r0 npm=8.10.0-r0
 
-# ENV COMMIT_SHA 'bd97779d5a1aa74c52914974e3badfaee0c4b3e6'
+ENV COMMIT_SHA '54aba3534e9e797b9a22c0e134fa2706effd2e9d'
 # hadolint ignore=DL3003
 RUN git config --global advice.detachedHead false && \
     git clone https://github.com/rand256/valetudo-mapper -b master /app && \
-    cd app && git checkout master
+    cd app && git checkout $COMMIT_SHA
 
 WORKDIR /app
 RUN npm install

--- a/valetudo-mapper/Dockerfile
+++ b/valetudo-mapper/Dockerfile
@@ -5,11 +5,11 @@ ENV LANG C.UTF-8
 
 RUN apk add --no-cache git=2.36.2-r0 npm=8.10.0-r0
 
-ENV COMMIT_SHA 'bd97779d5a1aa74c52914974e3badfaee0c4b3e6'
+# ENV COMMIT_SHA 'bd97779d5a1aa74c52914974e3badfaee0c4b3e6'
 # hadolint ignore=DL3003
 RUN git config --global advice.detachedHead false && \
     git clone https://github.com/rand256/valetudo-mapper -b master /app && \
-    cd app && git checkout $COMMIT_SHA
+    cd app && git checkout master
 
 WORKDIR /app
 RUN npm install

--- a/valetudo-mapper/config.yaml
+++ b/valetudo-mapper/config.yaml
@@ -1,5 +1,5 @@
 name: Valetudo Mapper
-version: 1.11.0
+version: 1.12.0
 slug: valetudomapper
 description: This is a simple companion service for Valetudo RE which generates
   the map pngs.


### PR DESCRIPTION
Update to latest valetudo-mapper which contains some [fixes](https://github.com/rand256/valetudo-mapper/commit/426718f5e037b5a4118a2ec154645e3966820a5b) for the new Home Assistant MQTT format.
It should fix the following warning which gets deprecated in 2024.2 release.

`
MQTT entity name starts with the device name in your config {'name': 'rockrobo_map', 'unique_id': 'rockrobo_map', 'device': {'manufacturer': 'Roborock', 'name': 'rockrobo', 'identifiers': ['rockrobo'], 'connections': []}, 'topic': 'valetudo/rockrobo/map', 'availability_mode': 'latest', 'payload_not_available': 'offline', 'encoding': 'utf-8', 'qos': 0, 'enabled_by_default': True, 'payload_available': 'online'}, this is not expected. Please correct your configuration. The device name prefix will be stripped off the entity name and becomes '_map'
`