### PR TITLE
[syncthing] Improve configuration

### DIFF
--- a/syncthing/CHANGELOG.md
+++ b/syncthing/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.18.0 - 2024-?-?
 
 * 🔨 Configure Syncthing via environment variables instead of CLI arguments where possible and properly separate config and database/state directories (thanks @salim-b | #450)
+* 🔨 Set `/share` as default folder path fallback (fixes #447, @salim-b).
 
 ## 1.17.0 - 2023-10-13
 

--- a/syncthing/CHANGELOG.md
+++ b/syncthing/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.18.0 - 2024-?-?
+
+* 🔨 Configure Syncthing via environment variables instead of CLI arguments where possible and properly separate config and database/state directories (thanks @salim-b | #450)
+
 ## 1.17.0 - 2023-10-13
 
 * 🔨 Set gui-address to first IP in container (thanks @reedy | #426)

--- a/syncthing/DOCS.md
+++ b/syncthing/DOCS.md
@@ -19,7 +19,6 @@ When using this add-on to permanently hold your data, put the synced folders ins
 - `/data`
 - `/media`
 - `/share`
-- `/config`
 - `/ssl`
 - `/addons`
 

--- a/syncthing/Dockerfile
+++ b/syncthing/Dockerfile
@@ -4,6 +4,13 @@ FROM $BUILD_FROM
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
 		"syncthing=1.25.0-r1"
 
+COPY root /
+
+ENV STCONFDIR=/config \
+    STDATADIR=/data \
+    STNODEFAULTFOLDER=1 \
+		STNORESTART=1 \
+    STNOUPGRADE=1
+
 ENTRYPOINT [ "/init" ]
 CMD []
-COPY root /

--- a/syncthing/Dockerfile
+++ b/syncthing/Dockerfile
@@ -9,7 +9,7 @@ COPY root /
 ENV STCONFDIR=/config \
     STDATADIR=/data \
     STNODEFAULTFOLDER=1 \
-		STNORESTART=1 \
+    STNORESTART=1 \
     STNOUPGRADE=1
 
 ENTRYPOINT [ "/init" ]

--- a/syncthing/Dockerfile
+++ b/syncthing/Dockerfile
@@ -6,7 +6,8 @@ RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/c
 
 COPY root /
 
-ENV STCONFDIR=/config \
+ENV HOME=/share \
+    STCONFDIR=/config \
     STDATADIR=/data \
     STNODEFAULTFOLDER=1 \
     STNORESTART=1 \

--- a/syncthing/config.yaml
+++ b/syncthing/config.yaml
@@ -26,9 +26,9 @@ ingress_port: 8384
 panel_title: Syncthing
 panel_icon: mdi:sync
 map:
-  - share:rw
-  - config:rw
-  - backup:rw
+  - addon_config:rw
   - addons:rw
-  - ssl:rw
+  - backup:rw
   - media:rw
+  - share:rw
+  - ssl:rw

--- a/syncthing/config.yaml
+++ b/syncthing/config.yaml
@@ -1,5 +1,5 @@
 name: Syncthing
-version: "1.17.0"
+version: "1.18.0"
 slug: syncthing
 description: "Syncthing is a continuous file synchronization program in a
   de-centralized way"

--- a/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
+++ b/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
@@ -2,19 +2,17 @@
 # shellcheck shell=bash
 set -e
 
-export STNOUPGRADE=1
-
-bashio::log.info 'Setup config'
-mkdir -p /data/config
+bashio::log.info 'Intializing Syncthing'
 
 ip=$(ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{sub("addr:",""); print $2}' | head -n 1)
 
 if [ -z "$ip" ]
 then
-      ip=0.0.0.0
+  ip=0.0.0.0
+  bashio::log.info "Couldn't detect IP address. Falling back to: $ip"
+else
+  bashio::log.info "Detected IP address: $ip"
 fi
 
-bashio::log.info "Detected IP Address: $ip"
-
-bashio::log.info 'Start syncthing'
-syncthing --no-browser --no-restart --home=/data/config --gui-address="$ip:8384"
+bashio::log.info 'Starting Syncthing'
+syncthing --gui-address="$ip:8384" --no-browser

--- a/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
+++ b/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
@@ -4,6 +4,7 @@ set -e
 
 bashio::log.info 'Intializing Syncthing'
 
+# determine IP address to serve Syncthing's GUI on
 ip=$(ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{sub("addr:",""); print $2}' | head -n 1)
 
 if [ -z "$ip" ]
@@ -12,6 +13,16 @@ then
   bashio::log.info "Couldn't detect IP address. Falling back to: $ip"
 else
   bashio::log.info "Detected IP address: $ip"
+fi
+
+# move config and DB state from old to new locations if necessary, cf. https://github.com/Poeschl/Hassio-Addons/pull/450
+if [ -d /data/config ]
+then
+  for CONF_FILE in config.xml cert.pem key.pem https-cert.pem https-key.pem
+  do
+    [ -f "/data/config/${CONF_FILE}" ] && mv -fu "/data/config/${CONF_FILE}" /config/ && rm -f "/data/config/${CONF_FILE}"
+  done
+  mv -fu /data/config/* /data/ && rm -f /data/config
 fi
 
 bashio::log.info 'Starting Syncthing'


### PR DESCRIPTION
Changes:

- Use [environment variables](https://docs.syncthing.net/includes/env-vars.html) instead of [CLI arguments](https://docs.syncthing.net/users/syncthing.html#options) where possible and properly separate [config and database/state directories](https://docs.syncthing.net/users/config.html#description) (related to https://github.com/Poeschl/Hassio-Addons/issues/447#issuecomment-1872160368).
  
  With this change, the add-on now mounts the new [`addon_config`](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) instead of `config` and stores Syncthing's
  - config in `/config` which maps to `/mnt/data/supervisor/addon_configs/243ffc37_syncthing/` on the host (I think?).
  - internal database state in `/data` which maps to `/mnt/data/supervisor/addons/data/243ffc37_syncthing/` on the host.

- Set `HOME=/share` as [default folder path fallback](https://github.com/syncthing/syncthing/blob/86a08eb87df2aa6cf1ab631120a0b918617a98b3/Dockerfile#L49), thus fix https://github.com/Poeschl/Hassio-Addons/issues/447.

- Slightly improve the logging in the s6 run script.

- Avoid [creating a default folder when generating an initial configuration / starting for the first time](https://docs.syncthing.net/users/syncthing.html#cmdoption-no-default-folder) by setting `STNODEFAULTFOLDER=1`. Syncthing shouldn't actually attempt to create a default folder since we set `STCONFDIR` and `STDATADIR` to paths that already exist. But in case anything goes south, `STNODEFAULTFOLDER=1` ensures we don't start writing to arbitrary paths.

Note that I haven't actually tested this PR yet 😬