### PR TITLE
Fix config migration

### DIFF
--- a/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
+++ b/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
@@ -20,9 +20,9 @@ if [ -d /data/config ]
 then
   for CONF_FILE in config.xml cert.pem key.pem https-cert.pem https-key.pem
   do
-    [ -f "/data/config/${CONF_FILE}" ] && mv -fu "/data/config/${CONF_FILE}" /config/ && rm -f "/data/config/${CONF_FILE}"
+    [ -f "/data/config/${CONF_FILE}" ] && mv -fn "/data/config/${CONF_FILE}" /config/ && rm -f "/data/config/${CONF_FILE}"
   done
-  mv -fu /data/config/* /data/ && rm -f /data/config
+  mv -fn /data/config/* /data/ && rm -f /data/config
 fi
 
 bashio::log.info 'Starting Syncthing'


### PR DESCRIPTION
The `mv` utility in the container doesn't support the [`-u` flag](https://manpages.debian.org/unstable/coreutils/mv.1.en.html#update) (BusyBox version?). Thus we use the [`-n` flag](https://manpages.debian.org/unstable/coreutils/mv.1.en.html#n) instead, which is supported.

**THIS PR CONTAINS A CRITICAL FIX FOR TODAY'S SYNCTHING UPDATE (v1.18.0). PLEASE MERGE ASAP.**