### PR TITLE
[syncthing] Fix config migration (again)

### DIFF
--- a/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
+++ b/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
@@ -22,7 +22,7 @@ then
   do
     [ -f "/data/config/${CONF_FILE}" ] && mv -fn "/data/config/${CONF_FILE}" /config/ && rm -f "/data/config/${CONF_FILE}"
   done
-  mv -fn /data/config/* /data/ && rm -f /data/config
+  mv -fn /data/config/* /data/ && rm -rf /data/config
 fi
 
 bashio::log.info 'Starting Syncthing'


### PR DESCRIPTION
Sorry, another cmd flag issue. `rm` requires the `-r` flag to delete directories. 🙄