### PR TITLE
 [syncthing] Fix #340

### DIFF
--- a/syncthing/DOCS.md
+++ b/syncthing/DOCS.md
@@ -2,6 +2,12 @@
 
 Configuration is done via [Syncthing's web UI](/hassio/ingress/243ffc37_syncthing) (embedded into Home Assistant). First start the add-on from the [*Info* tab](/hassio/addon/243ffc37_syncthing/info) and then click `OPEN WEB UI`.
 
+After starting up, Syncthing displays a notice (in a yellow box at the top) saying
+
+> Insecure admin access is enabled.
+
+This can safely be ignored since it [does not apply to this add-on](https://github.com/Poeschl/Hassio-Addons/issues/340).
+
 ## Syncthing Home Assistant integration
 
 If you want to monitor the Syncthing add-on via Home Assistant's [**Syncthing** integration](https://www.home-assistant.io/integrations/syncthing/), you need to expose Syncthing's web UI to the (local) network rather than only to the [Home Assistant Supervisor](https://developers.home-assistant.io/docs/supervisor).

--- a/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
+++ b/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing/run
@@ -27,3 +27,6 @@ fi
 
 bashio::log.info 'Starting Syncthing'
 syncthing --gui-address="$ip:8384" --no-browser
+
+# alleviate GUI authentication warning, cf. https://github.com/Poeschl/Hassio-Addons/issues/340
+syncthing cli config gui insecure-admin-access set true


### PR DESCRIPTION
Beware that this PR is untested. Fixes #340.

I'm unsure whether it's fine to do it like this. Maybe the main `syncthing` invocation (`syncthing --gui-address="$ip:8384" --no-browser`) must come last in the S6 run script for HA to be able to detect when the add-on crashes (and automatically restart it if desired)? In that case I wouldn't know how to run `syncthing cli config gui insecure-admin-access set true` since `syncthing cli` commands only work when Syncthing is already running...