### PR TITLE
[syncthing] Remove unneeded CLI args

### DIFF
--- a/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing-setup/run
+++ b/syncthing/root/etc/s6-overlay/s6-rc.d/syncthing-setup/run
@@ -16,5 +16,4 @@ fi
 bashio::net.wait_for 8384 "$ip"
 bashio::log.info 'Post-Start syncthing setup'
 
-apikey=$(grep -o '<apikey>[^<]*' /config/config.xml | sed 's/<apikey>//;s/<\/apikey>//')
-syncthing cli --gui-address="$ip:8384" --gui-apikey="$apikey" config gui insecure-admin-access set true
+syncthing cli config gui insecure-admin-access set true


### PR DESCRIPTION
In case of the `syncthing cli` subcommand, the `--gui-*` args are intended to access remote Syncthing instances and should not be necessary here since we're running on the same host, right?

(First I though the `--gui-*` args would be without effect for the `syncthing cli` subcommand and only relevant for `syncthing serve`. But [this forum post](https://forum.syncthing.net/t/ssh-webgui-forwarding-headless-server/18680/6) seems to indicate otherwise – the only meaningful mention of the `syncthing cli --gui-address` combo I could find online, in fact.)